### PR TITLE
Update premium subscription tiers in auto-bump

### DIFF
--- a/supabase/functions/auto-bump-listings/index.ts
+++ b/supabase/functions/auto-bump-listings/index.ts
@@ -67,7 +67,7 @@ serve(async (req) => {
       }
 
       // Check if user has premium subscription
-      if (!['small', 'medium', 'premium'].includes(profile.subscription_tier)) {
+      if (!['gold', 'premium', 'platinum'].includes(profile.subscription_tier)) {
         logStep(`User ${profile.id} does not have premium subscription (tier: ${profile.subscription_tier}), skipping`);
         continue;
       }


### PR DESCRIPTION
Changed the allowed subscription tiers for auto-bump listings from ['small', 'medium', 'premium'] to ['gold', 'premium', 'platinum'] to reflect updated premium tier definitions.